### PR TITLE
Remove supports_constraint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CxxWrap = "0.11"
-MathOptInterface = "0.9.14"
+MathOptInterface = "0.9.21"
 MathProgBase = "0.7"
 SemidefiniteModels = "~0.1.1"
 julia = "1.5"

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -104,8 +104,6 @@ MOI.supports_add_constrained_variables(::Optimizer, ::Type{MOI.Reals}) = false
 
 const SupportedSets = Union{MOI.Nonnegatives, MOI.PositiveSemidefiniteConeTriangle}
 MOI.supports_add_constrained_variables(::Optimizer, ::Type{<:SupportedSets}) = true
-# Remove this when support for MOI v0.9.14 is dropped
-MOI.supports_constraint(::Optimizer, ::Type{MOI.VectorOfVariables}, ::Type{<:SupportedSets}) = true
 function MOI.supports_constraint(
     ::Optimizer, ::Type{MOI.ScalarAffineFunction{Cdouble}},
     ::Type{MOI.EqualTo{Cdouble}})


### PR DESCRIPTION
This was left in https://github.com/jump-dev/SDPA.jl/pull/26 so that both MOI v0.9.14 and MOI v0.9.15 are supported, it can be removed now if we bump the MOI lower bound.
Similar to https://github.com/jump-dev/CSDP.jl/pull/61